### PR TITLE
Amend OFFSET_INCREMENT value

### DIFF
--- a/lib/google_analytics_service.rb
+++ b/lib/google_analytics_service.rb
@@ -9,8 +9,8 @@ class GoogleAnalyticsService
 
   #LIMIT and OFFSET_INCREMENT will be set to 100k in prod
   OFFSET = 0
-  LIMIT = 10
-  OFFSET_INCREMENT = 10
+  LIMIT = 10_000
+  OFFSET_INCREMENT = 10_000
 
   def initialize
     @ga_client = Client.new


### PR DESCRIPTION
Made a small tweak to the `OFFSET_INCREMENT` and `LIMIT` value to `10_000` for better readability. This is because when running the `search_analytics` script, it can take a while to finish up.

@AlexAvlonitis also suggested to could extract this value to the .env file, so we can amend this value without any code changes 👍