### PR TITLE
Order formatted data by descending page views

### DIFF
--- a/lib/formatter.rb
+++ b/lib/formatter.rb
@@ -10,7 +10,7 @@ class Formatter
 
   def consolidated_page_views
     normalise_data
-    @consolidated_page_views
+    sort_by_page_views_descending
   end
 
   private
@@ -61,5 +61,10 @@ class Formatter
 
   def page_not_found(page_data)
     page_data.title.include?(PAGE_NOT_FOUND)
+  end
+
+  def sort_by_page_views_descending
+    sorted_by_page_views_desc = @consolidated_page_views.sort_by {|_key, value| value}.reverse!
+    sorted_by_page_views_desc.to_h
   end
 end

--- a/spec/lib/formatter_spec.rb
+++ b/spec/lib/formatter_spec.rb
@@ -98,5 +98,19 @@ describe Formatter do
 
       expect(normalised_data).to be_empty
     end
+
+    it 'sorts the formatted data by page views (descending)' do
+      page_data = [
+        PageData.new("/example", "example", "20"),
+        PageData.new("/example-two", "example-two", "10"),
+        PageData.new("/example-three", "example-three", "30"),
+        PageData.new("/example-four", "example-four", "5")
+      ]
+
+      formatter = Formatter.new(page_data)
+
+      #Converts consolidated_page_views to an array for the test as RSpec eq doesn't match based on hash order
+      expect(formatter.consolidated_page_views.to_a).to eq([["/example-three", 30], ["/example", 20], ["/example-two", 10], ["/example-four", 5]])
+    end
   end
 end


### PR DESCRIPTION
The raw data from the API was formatted by descending page views. However, when it was formatted, the ordering did not stay in tact. This sorts the formatted data by descending page views.

Paired with @AlexAvlonitis